### PR TITLE
chore: refactor CLI and Makefile for flexibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ OUTPUT_DIR = output
 IMAGE_NAME = kurtis:latest
 DOCKER_REGISTRY = ethicalabs/kurtis
 CONFIG_MODULE = kurtis.config.default
+MODEL_NAME = mrs83/Kurtis-SmolLM2-360M-Instruct
 
 # Default target
 .PHONY: all
@@ -32,17 +33,17 @@ help:
 # Preprocess the dataset
 .PHONY: preprocessing
 preprocessing:
-	uv run $(PYTHON) -m $(MODULE) --config-module $(CONFIG_MODULE) dataset preprocessing
+	uv run $(PYTHON) -m $(MODULE) --config-module $(CONFIG_MODULE) dataset preprocess --dataset-config datasets.yaml
 
 # Train the model
 .PHONY: train
 train:
-	uv run $(PYTHON) -m $(MODULE) --config-module $(CONFIG_MODULE) model train
+	uv run $(PYTHON) -m $(MODULE) --config-module $(CONFIG_MODULE) model train --dataset-config datasets.yaml
 
 # Eval the model
 .PHONY: eval_model
 eval_model:
-	uv run $(PYTHON) -m $(MODULE) --config-module $(CONFIG_MODULE) model evaluate
+	uv run $(PYTHON) -m $(MODULE) --config-module $(CONFIG_MODULE) model evaluate --dataset-config datasets.yaml --model-name $(MODEL_NAME)
 
 
 # Start a chat session

--- a/kurtis/commands/dataset/preprocess.py
+++ b/kurtis/commands/dataset/preprocess.py
@@ -15,8 +15,9 @@ from kurtis.preprocess import preprocessing_main
 @click.option("--max-seq-length", default=1024, help="Max sequence length.")
 @click.option("--push", is_flag=True, help="Push dataset to Hugging Face.")
 @click.option("--dataset-config", help="Path to YAML dataset config.")
+@click.option("--model-name", help="Model name to use for tokenizer (overrides config).")
 @click.pass_context
-def command(ctx, max_seq_length, push, dataset_config):
+def command(ctx, max_seq_length, push, dataset_config, model_name):
     debug = ctx.obj["DEBUG"]
     config = ctx.obj["CONFIG"]
     preprocessing_main(
@@ -25,4 +26,5 @@ def command(ctx, max_seq_length, push, dataset_config):
         push=push,
         debug=debug,
         dataset_config_path=dataset_config,
+        model_name=model_name,
     )

--- a/kurtis/commands/model/chat.py
+++ b/kurtis/commands/model/chat.py
@@ -56,8 +56,14 @@ def handle_chat(config, model_dirname, model_path=None):
     "--model-path",
     help="Path to the model to chat with (overrides default).",
 )
+@click.option(
+    "--model-name",
+    help="Model name to chat with (alias for --model-path).",
+)
 @click.pass_context
-def command(ctx, output_dir, model_path):
+def command(ctx, output_dir, model_path, model_name):
     config = ctx.obj["CONFIG"]
     model_dirname = os.path.join(output_dir, config.MODEL_DPO_NAME)
-    handle_chat(config, model_dirname, model_path)
+    # Prefer model_name if provided, otherwise model_path
+    final_model_path = model_name or model_path
+    handle_chat(config, model_dirname, final_model_path)

--- a/kurtis/commands/model/evaluate.py
+++ b/kurtis/commands/model/evaluate.py
@@ -11,18 +11,18 @@ from kurtis.model import load_model_and_tokenizer
 from kurtis.evaluate import evaluate_main
 
 
-def handle_evaluation(config, model_dirname):
+def handle_evaluation(config, model_dirname, dataset_config=None, model_name=None):
     """
     Evaluate the model on configured datasets.
     """
     model, tokenizer = load_model_and_tokenizer(
         config,
-        model_name=config.INFERENCE_MODEL,
-        model_output=model_dirname,
+        model_name=model_name or config.INFERENCE_MODEL,
+        model_output=model_dirname if not model_name else None,
     )
     model.eval()
     click.echo("Testing the model on configured datasets...")
-    evaluate_main(model, tokenizer, config)
+    evaluate_main(model, tokenizer, config, dataset_config_path=dataset_config)
 
 
 @click.command(name="evaluate")
@@ -32,8 +32,13 @@ def handle_evaluation(config, model_dirname):
     default="./output",
     help="Directory to save or load the model and checkpoints.",
 )
+@click.option("--dataset-config", help="Path to YAML dataset config.")
+@click.option("--model-name", help="Model name or path to evaluate.")
 @click.pass_context
-def command(ctx, output_dir):
+def command(ctx, output_dir, dataset_config, model_name):
     config = ctx.obj["CONFIG"]
+    if dataset_config:
+        config.TRAINING_CONFIG["dataset_config_path"] = dataset_config
+        
     model_dirname = os.path.join(output_dir, config.MODEL_NAME)
-    handle_evaluation(config, model_dirname)
+    handle_evaluation(config, model_dirname, dataset_config, model_name)

--- a/kurtis/commands/model/train.py
+++ b/kurtis/commands/model/train.py
@@ -61,12 +61,7 @@ def handle_train(
 def command(ctx, output_dir, push, model_name, dataset_config):
     config = ctx.obj["CONFIG"]
 
-    # MPS Safety Check
-    if torch.backends.mps.is_available():
-        click.echo(
-            "Warning: MPS detected. Skipping actual training execution as requested for testing."
-        )
-        return
+
 
     # Ensure output directory exists
     os.makedirs(output_dir, exist_ok=True)

--- a/kurtis/evaluate.py
+++ b/kurtis/evaluate.py
@@ -114,12 +114,18 @@ def evaluate_main(
     debug=False,
     batch_size=8,
     eval_ratio=0.25,
+    dataset_config_path=None,
 ):
     click.echo("Starting evaluation process...")
 
     # Load datasets from config
-    click.echo("Testing on kurtis dataset")
-    dataset = load_dataset_from_config(config.EVALUATION_DATASET)
+    if dataset_config_path:
+        from kurtis.dataset import load_datasets_from_yaml
+        click.echo(f"Loading datasets from {dataset_config_path}")
+        dataset = load_datasets_from_yaml(dataset_config_path)
+    else:
+        click.echo("Testing on kurtis dataset")
+        dataset = load_dataset_from_config(config.EVALUATION_DATASET)
 
     val_dataset = dataset.select(range(max(1, int(eval_ratio * len(dataset)))))
 

--- a/kurtis/preprocess.py
+++ b/kurtis/preprocess.py
@@ -61,16 +61,15 @@ def process_dataset(dataset, split_ratio=0.05):
 
 
 def preprocessing_main(
-    config, max_length=512, push=False, debug=False, dataset_config_path=None
+    config, max_length=512, push=False, debug=False, dataset_config_path=None, model_name=None
 ):
     nltk.download("punkt")
     nltk.download("punkt_tab")
     if not torch.cuda.is_available():
         click.echo("CUDA is required to run data augmentation on initial dataset.")
 
-    _, tokenizer = load_model_and_tokenizer(
-        config, config.PREPROCESSING_TOKENIZER_MODEL
-    )
+    tokenizer_model = model_name or config.PREPROCESSING_TOKENIZER_MODEL
+    _, tokenizer = load_model_and_tokenizer(config, tokenizer_model)
 
     initial_dataset = prepare_initial_dataset(
         config, tokenizer, max_length, dataset_config_path


### PR DESCRIPTION
chore: refactor CLI and Makefile for flexibility and consistency

- Add `--model-name` support to chat and evaluate commands
- Add `--dataset-config` support to train, preprocess and evaluate.
- Update Makefile to use `datasets.yaml` and `MODEL_NAME` variable.
- Fix `preprocessing` target name in Makefile.
- Remove MPS safety check from `train` command.